### PR TITLE
Add Anitya external version checker

### DIFF
--- a/com.w1hkj.flrig.metainfo.xml
+++ b/com.w1hkj.flrig.metainfo.xml
@@ -19,7 +19,7 @@
  </description>
  <screenshots>
   <screenshot type="default">
-   <image>http://www.w1hkj.com/flrig-help/ui-narrow-ic7200.png</image>
+   <image>http://www.w1hkj.com/flrig-help/IC7100-ui-narrow.png</image>
   </screenshot>
  </screenshots>
  <releases>

--- a/com.w1hkj.flrig.yml
+++ b/com.w1hkj.flrig.yml
@@ -31,8 +31,8 @@ modules:
   - name: flrig
     sources:
       - type: archive
-        url: http://www.w1hkj.com/files/flrig/flrig-1.3.52.tar.gz
-        sha256: 887e84b147822d755181a9d15f4ffdd3d4a54c8255154a3c2b826e80002981a1
+        url: http://www.w1hkj.com/files/flrig/flrig-1.3.54.tar.gz
+        sha256: cf0d318b80159e6f158bfa16921d770bd06369b38a52d65a5662cdfbecca1ae8
         x-checker-data:
           type: anitya
           project-id: 9624

--- a/com.w1hkj.flrig.yml
+++ b/com.w1hkj.flrig.yml
@@ -33,6 +33,10 @@ modules:
       - type: archive
         url: http://www.w1hkj.com/files/flrig/flrig-1.3.52.tar.gz
         sha256: 887e84b147822d755181a9d15f4ffdd3d4a54c8255154a3c2b826e80002981a1
+        x-checker-data:
+          type: anitya
+          project-id: 9624
+          url-template: http://www.w1hkj.com/files/flrig/flrig-$version.tar.gz
   - name: metainfo
     buildsystem: simple
     build-commands:


### PR DESCRIPTION
This should let https://github.com/flathub/flatpak-external-data-checker automatically file issues when the upstream version is updated. This tracks flrig via https://release-monitoring.org/project/9624/