### PR TITLE
Add launchable tag to AppStream metadata

### DIFF
--- a/com.w1hkj.flrig.metainfo.xml
+++ b/com.w1hkj.flrig.metainfo.xml
@@ -39,4 +39,5 @@
    <release version="1.3.54" date="2021-02-03"/>
  </releases>
  <content_rating type="oars-1.1"/>
+ <launchable type="desktop-id">com.w1hkj.flrig.desktop</launchable>
 </component>


### PR DESCRIPTION
This tag is now considered as mandatory.